### PR TITLE
Use jasmine instead of jasmine-node

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -23,6 +23,6 @@
     "webdriver": "0.0.1",
     "webdriver-manager": "7.0.1",
     "webdrivercss": "sandersky/webdrivercss",
-    "webdriverio": "^3.1.0"
+    "webdriverio": "^2.4.5"
   }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -16,13 +16,13 @@
   "author": "Peter Banka",
   "license": "MIT",
   "devDependencies": {
-    "beaker": "sandersky/beaker",
+    "beaker": "^3.10.1",
     "gm": "1.18.1",
     "protractor": "^2.1.0",
     "raw-loader": "^0.5.1",
     "webdriver": "0.0.1",
     "webdriver-manager": "7.0.1",
-    "webdrivercss": "sandersky/webdrivercss",
+    "webdrivercss": "^1.1.4",
     "webdriverio": "^2.4.5"
   }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -23,6 +23,6 @@
     "webdriver": "0.0.1",
     "webdriver-manager": "7.0.1",
     "webdrivercss": "^1.1.4",
-    "webdriverio": "^2.4.5"
+    "webdriverio": "^3.1.0"
   }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -16,13 +16,13 @@
   "author": "Peter Banka",
   "license": "MIT",
   "devDependencies": {
-    "beaker": "^3.10.0",
+    "beaker": "sandersky/beaker",
     "gm": "1.18.1",
     "protractor": "^2.1.0",
     "raw-loader": "^0.5.1",
     "webdriver": "0.0.1",
     "webdriver-manager": "7.0.1",
-    "webdrivercss": "^1.1.4",
+    "webdrivercss": "sandersky/webdrivercss",
     "webdriverio": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriverio-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Server for running webdriverio tests",
   "repository": {
     "type": "git",

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -78,7 +78,7 @@ function testIt {
 
 	echo "Running jasmine tests with http port $HTTP_PORT and selenium port $SELENIUM_PORT"
     TEST_STATUS=0
-    ./node_modules/.bin/jasmine
+    ./node_modules/.bin/jasmine JASMINE_CONFIG_PATH=spec/e2e/jasmine.json
 
 	kill $(lsof -t -i:$HTTP_PORT) || echo 'ERROR killing http-server'
 	kill $(lsof -t -i:$SELENIUM_PORT) || echo 'ERROR killing selenium server'

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -23,7 +23,6 @@ set -u
 
 TEST_CONFIG='spec/e2e/test-config.json'
 NODE_SPECS=spec/e2e
-JASMINE_NODE_OPTS='--captureExceptions --verbose'
 
 TARBALL=$1
 ENTRY_POINT=$2
@@ -77,9 +76,9 @@ function testIt {
         http.port:$HTTP_PORT \
         http.entryPoint:$ENTRY_POINT
 
-	echo "Running jasmine-node tests with http port $HTTP_PORT and selenium port $SELENIUM_PORT"
+	echo "Running jasmine tests with http port $HTTP_PORT and selenium port $SELENIUM_PORT"
     TEST_STATUS=0
-    ./node_modules/.bin/jasmine-node $JASMINE_NODE_OPTS $NODE_SPECS || TEST_STATUS=1
+    ./node_modules/.bin/jasmine
 
 	kill $(lsof -t -i:$HTTP_PORT) || echo 'ERROR killing http-server'
 	kill $(lsof -t -i:$SELENIUM_PORT) || echo 'ERROR killing selenium server'

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -78,7 +78,7 @@ function testIt {
 
 	echo "Running jasmine tests with http port $HTTP_PORT and selenium port $SELENIUM_PORT"
     TEST_STATUS=0
-    ./node_modules/.bin/jasmine JASMINE_CONFIG_PATH=spec/e2e/jasmine.json
+    ./node_modules/.bin/jasmine JASMINE_CONFIG_PATH=${NODE_SPECS}/jasmine.json
 
 	kill $(lsof -t -i:$HTTP_PORT) || echo 'ERROR killing http-server'
 	kill $(lsof -t -i:$SELENIUM_PORT) || echo 'ERROR killing selenium server'


### PR DESCRIPTION
Start using `jasmine` over `jasmine-node` so we can use the latest version of `jasmine` and leverage `beforeAll` and `afterAll` to speed up end to end tests.